### PR TITLE
support bulk poolset

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.63])
-AC_INIT([mochi-quintain], [0.1], [],[],[])
+AC_INIT([mochi-quintain], [0.2], [],[],[])
 AC_CONFIG_MACRO_DIR([m4])
 LT_INIT
 

--- a/include/quintain-client.h
+++ b/include/quintain-client.h
@@ -39,7 +39,8 @@ int quintain_work(quintain_provider_handle_t provider,
                   int                        resp_buffer_size,
                   hg_size_t                  bulk_size,
                   hg_bulk_op_t               bulk_op,
-                  void*                      bulk_buffer);
+                  void*                      bulk_buffer,
+                  int                        flags);
 
 #ifdef __cplusplus
 }

--- a/include/quintain-server.h
+++ b/include/quintain-server.h
@@ -63,6 +63,14 @@ int quintain_provider_register(margo_instance_id mid,
  */
 int quintain_provider_deregister(quintain_provider_t provider);
 
+/**
+ * Retrieves complete configuration of quintain provider, encoded as json
+ *
+ * @param [in] provider quintain provider
+ * @returns null terminated string that must be free'd by caller
+ */
+char* quintain_provider_get_config(quintain_provider_t provider);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/quintain.h
+++ b/include/quintain.h
@@ -32,6 +32,9 @@ extern "C" {
 #define QTN_ERR_MERCURY          (-3) /* Mercury error */
 #define QTN_ERR_UNKNOWN_PROVIDER (-3) /* can't find provider */
 
+/* flags for workload operations */
+#define QTN_WORK_USE_SERVER_POOLSET 1
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/quintain-bedrock-module.c
+++ b/src/quintain-bedrock-module.c
@@ -48,11 +48,7 @@ static int quintain_deregister_provider(bedrock_module_provider_t provider)
 
 static char* quintain_get_provider_config(bedrock_module_provider_t provider)
 {
-#if 0
     return (quintain_provider_get_config(provider));
-#else
-    return strdup("{}");
-#endif
 }
 
 static int quintain_init_client(bedrock_args_t           args,

--- a/src/quintain-benchmark.c
+++ b/src/quintain-benchmark.c
@@ -262,7 +262,7 @@ int main(int argc, char** argv)
         /* retrieve local configuration */
         cli_cfg_str = margo_get_config(mid);
 
-        gzprintf(f, "\"margo (server)\" : %s\n", svr_cfg_str);
+        gzprintf(f, "%s\n", svr_cfg_str);
         gzprintf(f, "\"margo (client)\" : %s\n", cli_cfg_str);
         gzprintf(f, "\"quintain-benchmark\" : %s\n",
                  json_object_to_json_string_ext(

--- a/src/quintain-benchmark.c
+++ b/src/quintain-benchmark.c
@@ -25,47 +25,11 @@
 #include <ssg.h>
 #include <quintain-client.h>
 
+#include "quintain-macros.h"
+
 /* record up to 32 million (power of 2) samples.  This will take 256 MiB of RAM
  * per rank */
 #define MAX_SAMPLES (32 * 1024 * 1024)
-
-// Overrides a field with an integer. If the field already existed and was
-// different from the new value, and __warning is true, prints a warning.
-#define CONFIG_OVERRIDE_INTEGER(__config, __key, __value, __warning)          \
-    do {                                                                      \
-        struct json_object* _tmp = json_object_object_get(__config, __key);   \
-        if (_tmp && __warning) {                                              \
-            if (!json_object_is_type(_tmp, json_type_int))                    \
-                fprintf(stderr, "Overriding field \"%s\" with value %d",      \
-                        __key, (int)__value);                                 \
-            else if (json_object_get_int(_tmp) != __value)                    \
-                fprintf(stderr, "Overriding field \"%s\" (%d) with value %d", \
-                        __key, json_object_get_int(_tmp), __value);           \
-        }                                                                     \
-        json_object_object_add(__config, __key,                               \
-                               json_object_new_int64(__value));               \
-    } while (0)
-
-// Checks if a JSON object has a particular key and its value is of the
-// specified type (not array or object or null). If the field does not exist,
-// creates it with the provided value.. If the field exists but is not of type
-// object, prints an error and return -1. After a call to this macro, __out is
-// set to the ceated/found field.
-#define CONFIG_HAS_OR_CREATE(__config, __type, __key, __value, __out)    \
-    do {                                                                 \
-        __out = json_object_object_get(__config, __key);                 \
-        if (__out && !json_object_is_type(__out, json_type_##__type)) {  \
-            fprintf(stderr,                                              \
-                    "\"%s\" in configuration but has an incorrect type " \
-                    "(expected %s)",                                     \
-                    __key, #__type);                                     \
-            return -1;                                                   \
-        }                                                                \
-        if (!__out) {                                                    \
-            __out = json_object_new_##__type(__value);                   \
-            json_object_object_add(__config, __key, __out);              \
-        }                                                                \
-    } while (0)
 
 struct options {
     char group_file[256];

--- a/src/quintain-client.c
+++ b/src/quintain-client.c
@@ -159,7 +159,8 @@ int quintain_work(quintain_provider_handle_t provider,
                   int                        resp_buffer_size,
                   hg_size_t                  bulk_size,
                   hg_bulk_op_t               bulk_op,
-                  void*                      bulk_buffer)
+                  void*                      bulk_buffer,
+                  int                        flags)
 {
     hg_handle_t    handle = HG_HANDLE_NULL;
     qtn_work_in_t  in;

--- a/src/quintain-rpc.h
+++ b/src/quintain-rpc.h
@@ -19,6 +19,7 @@ typedef struct {
         resp_buffer_size; /* size of buffer provider should give in response */
     uint64_t  req_buffer_size; /* size of buffer in this request */
     uint64_t  bulk_size;       /* bulk xfer size */
+    uint32_t  flags;           /* flags to modify behavior */
     uint32_t  bulk_op;         /* what type of bulk xfer to do */
     hg_bulk_t bulk_handle;     /* bulk handle (if set) for bulk xfer */
     char*     req_buffer;      /* dummy buffer */

--- a/src/quintain-server.c
+++ b/src/quintain-server.c
@@ -104,7 +104,8 @@ int quintain_provider_register(margo_instance_id mid,
         ret = QTN_ERR_ALLOCATION;
         goto error;
     }
-    tmp_provider->mid = mid;
+    tmp_provider->json_cfg = config;
+    tmp_provider->mid      = mid;
 
     if (args.rpc_pool != NULL)
         tmp_provider->handler_pool = args.rpc_pool;

--- a/src/quintain-server.c
+++ b/src/quintain-server.c
@@ -41,6 +41,7 @@ static void quintain_server_finalize_cb(void* data)
     struct quintain_provider* provider = (struct quintain_provider*)data;
     assert(provider);
 
+    if (provider->poolset) margo_bulk_poolset_destroy(provider->poolset);
     free(provider);
     return;
 }
@@ -245,20 +246,33 @@ static void qtn_work_ult(hg_handle_t handle)
         out.resp_buffer = NULL;
 
     if (in.bulk_size) {
-        bulk_buffer = malloc(in.bulk_size);
-        if (!bulk_buffer) {
-            out.ret = QTN_ERR_ALLOCATION;
-            goto finish;
+        /* we were asked to perform a bulk transfer */
+        if (in.flags & QTN_WORK_USE_SERVER_POOLSET) {
+            /* get buffer from poolset */
+            out.ret = margo_bulk_poolset_get(provider->poolset, in.bulk_size,
+                                             &bulk_handle);
+            if (out.ret != 0) {
+                out.ret = QTN_ERR_ALLOCATION;
+                goto finish;
+            }
+        } else {
+            /* allocate buffer and register */
+            bulk_buffer = malloc(in.bulk_size);
+            if (!bulk_buffer) {
+                out.ret = QTN_ERR_ALLOCATION;
+                goto finish;
+            }
+            if (in.bulk_op == HG_BULK_PUSH) bulk_flag = HG_BULK_READ_ONLY;
+            out.ret = margo_bulk_create(mid, 1, (void**)(&bulk_buffer),
+                                        &in.bulk_size, bulk_flag, &bulk_handle);
+            if (out.ret != HG_SUCCESS) goto finish;
         }
-        if (in.bulk_op == HG_BULK_PUSH) bulk_flag = HG_BULK_READ_ONLY;
-        out.ret = margo_bulk_create(mid, 1, (void**)(&bulk_buffer),
-                                    &in.bulk_size, bulk_flag, &bulk_handle);
-        if (out.ret != HG_SUCCESS) goto finish;
-    }
 
-    /* transfer */
-    out.ret = margo_bulk_transfer(mid, in.bulk_op, info->addr, in.bulk_handle,
+        /* transfer */
+        out.ret
+            = margo_bulk_transfer(mid, in.bulk_op, info->addr, in.bulk_handle,
                                   0, bulk_handle, 0, in.bulk_size);
+    }
 
 finish:
     margo_respond(handle, &out);


### PR DESCRIPTION
- parameterized on server (as in bake provider)
- client can specify whether to use it or not per-rpc
- benchmark now reports provider config in output also