### PR TITLE
nested benchmark json

### DIFF
--- a/tests/quintain-benchmark-example.json
+++ b/tests/quintain-benchmark-example.json
@@ -1,1 +1,7 @@
-{ }
+{
+    "margo": {
+        "mercury": {
+            "auto_sm":true
+        }
+    }
+}


### PR DESCRIPTION
Allow inclusion of "margo" object within existing json configuration.  If present, it will be passed into `margo_init_ext()` to allow user to control  client-side margo, mercury, and argobots parameters.

Also unifies json file similarly in benchmark output; the margo information is embedded in the benchmark json rather than listed separately.

This PR deprecates #9 