### PR TITLE
report ru_maxrss in quintain provider config

### DIFF
--- a/src/quintain-macros.h
+++ b/src/quintain-macros.h
@@ -22,7 +22,7 @@ static const int json_type_int64 = json_type_int;
                         __key, (int)__value);                                 \
             else if (json_object_get_int(_tmp) != __value)                    \
                 fprintf(stderr, "Overriding field \"%s\" (%d) with value %d", \
-                        __key, json_object_get_int(_tmp), __value);           \
+                        __key, json_object_get_int(_tmp), (int)__value);      \
         }                                                                     \
         json_object_object_add(__config, __key,                               \
                                json_object_new_int64(__value));               \


### PR DESCRIPTION
- this gets reported back to client and stored in benchmark results
- ru_maxrss is the maximum resident memory usage, in KiB
- not retrieved until get_config is called explicitly