### PR TITLE
WIP: use the bedrock C query API

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -85,6 +85,18 @@ LIBS="$BEDROCK_LIBS $LIBS"
 CPPFLAGS="$BEDROCK_CFLAGS $CPPFLAGS"
 CFLAGS="$BEDROCK_CFLAGS $CFLAGS"
 
+# see if bedrock has a C API for retrieving configuration
+AC_MSG_CHECKING(for bedrock_service_query_config in Bedrock)
+AC_TRY_COMPILE([
+#include <bedrock/service-handle.h>
+], [
+char* foo = bedrock_service_query_config(NULL, "");
+],
+AC_MSG_RESULT(yes),
+AC_MSG_RESULT(no)
+AC_MSG_ERROR([This version of Bedrock does not support bedrock_service_query_config])
+)
+
 PKG_CHECK_MODULES([SSG], [ssg >= 0.5],[],
    [AC_MSG_ERROR([Could not find working SSG installationi v0.5 or higher])])
 LIBS="$SSG_LIBS $LIBS"

--- a/include/quintain-client.h
+++ b/include/quintain-client.h
@@ -31,9 +31,6 @@ int quintain_provider_handle_create(quintain_client_t           client,
 
 int quintain_provider_handle_release(quintain_provider_handle_t handle);
 
-int quintain_get_server_config(quintain_provider_handle_t provider,
-                               char**                     config);
-
 int quintain_work(quintain_provider_handle_t provider,
                   int                        req_buffer_size,
                   int                        resp_buffer_size,

--- a/src/Makefile.subdir
+++ b/src/Makefile.subdir
@@ -11,5 +11,5 @@ dist_bin_SCRIPTS += src/quintain-benchmark-parse.sh
 
 if HAVE_MPI
 bin_PROGRAMS += src/quintain-benchmark
-src_quintain_benchmark_LDADD = src/libquintain-client.la
+src_quintain_benchmark_LDADD = src/libquintain-client.la -lbedrock-client
 endif

--- a/src/quintain-rpc.h
+++ b/src/quintain-rpc.h
@@ -11,9 +11,6 @@
 #include <mercury_proc_string.h>
 #include <quintain.h>
 
-MERCURY_GEN_PROC(qtn_get_server_config_out_t,
-                 ((int32_t)(ret))((hg_string_t)(cfg_str)))
-
 typedef struct {
     uint64_t
         resp_buffer_size; /* size of buffer provider should give in response */


### PR DESCRIPTION
This PR uses the bedrock C query API in place of quintain's built-in ad-hoc configuration query function.

The resulting JSON is more complete, in particular because it displays how providers are mapped to argobots pools.

Need to:
- [x] remove temporary BEDROCK_SUCCESS def
- [x] remove old quintain query function
- [x] "pretty" print the json; current output is very dense
- [x] autoconf test for presence of bedrock API so we get a clean compile-time error against old versions of bedrock (this will be mandatory, though, no fallback)