### PR TITLE
pass rpc pool provided by bedrock to provider

### DIFF
--- a/src/quintain-bedrock-module.c
+++ b/src/quintain-bedrock-module.c
@@ -28,6 +28,7 @@ static int quintain_register_provider(bedrock_args_t             args,
     QTN_TRACE(mid, " -> name          = %s", name);
 
     bpargs.json_config = config;
+    bpargs.rpc_pool    = pool;
 
     ret = quintain_provider_register(mid, provider_id, &bpargs,
                                      (quintain_provider_t*)provider);


### PR DESCRIPTION
Fixes bug in which all RPCs are executed on default RPC handler pool instead of explicit pool configured via bedrock json.