### PR TITLE
add support for multiple servers

### DIFF
--- a/tests/Makefile.subdir
+++ b/tests/Makefile.subdir
@@ -5,12 +5,15 @@ TESTS_ENVIRONMENT += \
 check_PROGRAMS +=
 
 TESTS += \
- tests/basic.sh
+ tests/basic.sh\
+ tests/multi.sh
 
 EXTRA_DIST += \
  tests/basic.sh \
  tests/mochi-quintain-provider.json\
- tests/quintain-benchmark-example.json
+ tests/quintain-benchmark-example.json\
+ tests/mochi-quintain-provider-2svr-A.json\
+ tests/mochi-quintain-provider-2svr-B.json
 
 DISTCLEANFILES += \
     test-output.gz \

--- a/tests/mochi-quintain-provider-2svr-A.json
+++ b/tests/mochi-quintain-provider-2svr-A.json
@@ -1,0 +1,34 @@
+{
+    "margo" : {
+    },
+    "libraries" : [
+        "libquintain-bedrock.so",
+        "libflock-bedrock-module.so"
+    ],
+    "providers" : [
+        {
+            "name" : "my_quintain_provider",
+            "type" : "quintain",
+            "provider_id" : 1,
+            "dependencies": {
+                "pool" : "__primary__"
+            },
+            "config" : {}
+        },
+        {
+            "name" : "quintain_group",
+            "type" : "flock",
+            "provider_id" : 2,
+            "dependencies": {
+                "pool" : "__primary__"
+            },
+            "config": {
+                  "bootstrap": "self",
+                  "file": "./quintain.flock.json",
+                  "group": {
+                      "type": "centralized"
+                  }
+            }
+        }
+    ]
+}

--- a/tests/mochi-quintain-provider-2svr-B.json
+++ b/tests/mochi-quintain-provider-2svr-B.json
@@ -1,0 +1,34 @@
+{
+    "margo" : {
+    },
+    "libraries" : [
+        "libquintain-bedrock.so",
+        "libflock-bedrock-module.so"
+    ],
+    "providers" : [
+        {
+            "name" : "my_quintain_provider",
+            "type" : "quintain",
+            "provider_id" : 1,
+            "dependencies": {
+                "pool" : "__primary__"
+            },
+            "config" : {}
+        },
+        {
+            "name" : "quintain_group",
+            "type" : "flock",
+            "provider_id" : 2,
+            "dependencies": {
+                "pool" : "__primary__"
+            },
+            "config": {
+                  "bootstrap": "join",
+                  "file": "./quintain.flock.json",
+                  "group": {
+                      "type": "centralized"
+                  }
+            }
+        }
+    ]
+}

--- a/tests/multi.sh
+++ b/tests/multi.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+if [ -z $srcdir ]; then
+    echo srcdir variable not set.
+    exit 1
+fi
+
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$PWD/src/.libs"
+
+bedrock -c $srcdir/tests/mochi-quintain-provider-2svr-A.json na+sm:// &
+sleep 2
+bedrock -c $srcdir/tests/mochi-quintain-provider-2svr-B.json na+sm:// &
+sleep 2
+
+mpiexec -n 2 src/quintain-benchmark -g quintain.flock.json -j $srcdir/tests/quintain-benchmark-example.json -o test-output
+
+bedrock-shutdown -f quintain.flock.json na+sm://


### PR DESCRIPTION
Clients will now round robin select a single quintain provider out of the flock group to issue requests to, rather than all contacting the same provider.