### PR TITLE
WIP: ability to enable HPCToolkit profiling on first quintain work RPC

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -98,6 +98,25 @@ LIBS="$ZLIB_LIBS $LIBS"
 CPPFLAGS="$ZLIB_CFLAGS $CPPFLAGS"
 CFLAGS="$ZLIB_CFLAGS $CFLAGS"
 
+AC_ARG_WITH([hpctoolkit],
+[AS_HELP_STRING([--with-hpctoolkit],
+  [enable explicit support for HPCToolkit profiling control])],
+[],
+[with_hpctoolkit=no])
+
+# if hpctoolkit support not disabled, check for header and library
+if test x$with_hpctoolkit != xno; then
+  # guess that hpctoolkit might be in the spack env.  Otherwise the user
+  # needs to set LDFLAGS appropriately at configure time
+  LIBS="-L$SPACK_ENV/.spack-env/view/lib/hpctoolkit $LIBS"
+  AC_CHECK_HEADER([hpctoolkit.h],
+     [AC_CHECK_LIB(hpctoolkit, hpctoolkit_sampling_start,
+         [AC_DEFINE(HAVE_HPCTOOLKIT, 1, [HPCToolkit support enabled])
+          LIBS="-lhpctoolkit $LIBS"],
+         [AC_MSG_ERROR(Cannot find required hpctoolkit_sampling_start() in libhpctoolkit)])],
+     [AC_MSG_ERROR(Cannot find hpctoolkit headers)])
+fi
+
 # optional mpi; this will cause the benchmark program to be built as well,
 # in addition to the provider piece
 AC_MSG_CHECKING([If MPI programs can be compiled])

--- a/src/quintain-server.c
+++ b/src/quintain-server.c
@@ -18,6 +18,10 @@
 #include <margo-bulk-pool.h>
 #include <quintain-server.h>
 
+#ifdef HAVE_HPCTOOLKIT
+    #include <hpctoolkit.h>
+#endif
+
 #include "quintain-rpc.h"
 #include "quintain-macros.h"
 
@@ -172,6 +176,10 @@ int quintain_provider_deregister(quintain_provider_t provider)
     return QTN_SUCCESS;
 }
 
+#ifdef HAVE_HPCTOOLKIT
+static int hpctoolkit_started = 0;
+#endif
+
 static void qtn_work_ult(hg_handle_t handle)
 {
     margo_instance_id     mid = MARGO_INSTANCE_NULL;
@@ -185,6 +193,13 @@ static void qtn_work_ult(hg_handle_t handle)
     hg_bulk_t             bulk_handle = HG_BULK_NULL;
 
     memset(&out, 0, sizeof(out));
+
+#ifdef HAVE_HPCTOOLKIT
+    if (!hpctoolkit_started) {
+        hpctoolkit_sampling_start();
+        hpctoolkit_started = 1;
+    }
+#endif
 
     mid = margo_hg_handle_get_instance(handle);
     assert(mid);


### PR DESCRIPTION
This adds an option to have quintain enable HPCToolkit profiling when the first benchmark RPC arrives.  This is useful to defer server sampling until the benchmark has successfully launched and begun execution.